### PR TITLE
Fix remove-from-parent check

### DIFF
--- a/src/Range.php
+++ b/src/Range.php
@@ -801,7 +801,7 @@ final class Range extends AbstractRange implements Stringable
             $referenceNode = $referenceNode->nextSibling;
         }
 
-        if (!$node->parentNode) {
+        if ($node->parentNode) {
             $node->parentNode->removeNode($node);
         }
 


### PR DESCRIPTION
This implements the following line in the spec:

> If node’s parent is non-null, then remove node.

Fixes #2