### PR TITLE
Fix splitText step of insertNode

### DIFF
--- a/src/Range.php
+++ b/src/Range.php
@@ -794,7 +794,7 @@ final class Range extends AbstractRange implements Stringable
         $parent->ensurePreinsertionValidity($node, $referenceNode);
 
         if ($this->startNode instanceof Text) {
-            $this->startNode->splitText($this->startOffset);
+            $referenceNode = $this->startNode->splitText($this->startOffset);
         }
 
         if ($node === $referenceNode) {


### PR DESCRIPTION
From the specification:

> If range’s start node is a Text node, set referenceNode to the result of splitting it with offset range’s start offset.