### PR TITLE
Range: Optimize parent check in computePosition()

### DIFF
--- a/src/Range.php
+++ b/src/Range.php
@@ -1226,13 +1226,9 @@ final class Range extends AbstractRange implements Stringable
 
         if ($ancestor) {
             $child = $boundaryPointB[0];
-            $childNodes = $boundaryPointA[0]
-                ->childNodes
-                ->getIterator()
-                ->getArrayCopy();
 
             while ($child) {
-                if (in_array($child, $childNodes, true)) {
+                if ($child->parentNode === $boundaryPointA[0]) {
                     break;
                 }
 


### PR DESCRIPTION
We can check whether a node is a child of another node directly,
without iterating over all its children.

Upstreamed from:
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/DiscussionTools/+/635119