### PR TITLE
Range::computePosition: Avoid slow closure

### DIFF
--- a/src/Range.php
+++ b/src/Range.php
@@ -1095,14 +1095,20 @@ final class Range extends AbstractRange implements Stringable
         $tw = new TreeWalker(
             $boundaryPointB[0]->getRootNode(),
             NodeFilter::SHOW_ALL,
-            static function (Node $node) use ($boundaryPointA): int {
-                if ($node === $boundaryPointA[0]) {
-                    return NodeFilter::FILTER_ACCEPT;
-                }
+            new class implements NodeFilter {
+                public $node;
 
-                return NodeFilter::FILTER_SKIP;
+                public function acceptNode(Node $node): int
+                {
+                    if ($node === $this->node) {
+                        return NodeFilter::FILTER_ACCEPT;
+                    }
+
+                    return NodeFilter::FILTER_SKIP;
+                }
             }
         );
+        $tw->filter->node = $boundaryPointA[0];
         $tw->currentNode = $boundaryPointB[0];
 
         $AFollowsB = $tw->nextNode();


### PR DESCRIPTION
This was faster in a particular test case but I'm not sure
if it's actually better.